### PR TITLE
Enable batch processing in Face Fit or Restore node

### DIFF
--- a/nodes/face_wrapper.py
+++ b/nodes/face_wrapper.py
@@ -243,7 +243,7 @@ class FaceWrapper:
         """
         if pipe is None:
             pipe = {
-                "workflow": "single_image",
+                "workflow": "image",
                 "current_frame": 0,
                 "frames": {}
             }


### PR DESCRIPTION
## Summary
- support batch input for the **image** workflow in `FaceFitAndRestore`
- rename workflow option from `single_image` to `image`
- update `FaceWrapper` default pipe accordingly

## Testing
- `python -m py_compile $(find . -name '*.py')`
- `pip install -r requirements.txt` *(fails: building dlib cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_686b8be9ef94832cb125c767f846a4d6