### PR TITLE
Document v2 nodes and add roundtrip test

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,28 +1,56 @@
 import os
 
-from .nodes.image_feeder import ImageFeeder
-from .nodes.image_filters import HighPassFilter
-from .nodes.face_wrapper import FaceWrapper
-from .nodes.face_fit_and_restore import FaceFitAndRestore
-from .nodes.face_tracker import FaceTracker
+_SKIP_IMPORTS = os.environ.get("FACEPROCESSOR_SKIP_IMPORTS") == "1"
+
+if not _SKIP_IMPORTS:
+    from .nodes.image_feeder import ImageFeeder
+    from .nodes.image_filters import HighPassFilter
+    from .nodes.face_wrapper import FaceWrapper
+    from .nodes.face_fit_and_restore import FaceFitAndRestore
+    from .faceprocessor_v2.nodes_fit_restore import FaceFitAndRestoreV2
+    from .faceprocessor_v2.nodes_wrapper import FaceWrapperV2
+    from .nodes.face_tracker import FaceTracker
+else:  # pragma: no cover - used only when optional deps are missing
+    ImageFeeder = None
+    HighPassFilter = None
+    FaceWrapper = None
+    FaceFitAndRestore = None
+    FaceFitAndRestoreV2 = None
+    FaceWrapperV2 = None
+    FaceTracker = None
 
 # Get the path to the current directory
 NODE_PATH = os.path.dirname(os.path.realpath(__file__))
 
-NODE_CLASS_MAPPINGS = {
-    "FaceFitAndRestore": FaceFitAndRestore,
-    "FaceWrapper": FaceWrapper,
-    "HighPassFilter": HighPassFilter,
-    "ImageFeeder": ImageFeeder,
-    "FaceTracker": FaceTracker
-}
+NODE_CLASS_MAPPINGS = {}
+NODE_DISPLAY_NAME_MAPPINGS = {}
 
-NODE_DISPLAY_NAME_MAPPINGS = {
-    "FaceFitAndRestore": "Face Fit or Restore",
-    "FaceWrapper": "Face Wrapper",
-    "HighPassFilter": "High Pass Filter (HPF)",
-    "ImageFeeder": "Image Feeder",
-    "FaceTracker": "Face Tracker"
-}
+if FaceFitAndRestore is not None:
+    NODE_CLASS_MAPPINGS["FaceFitAndRestore"] = FaceFitAndRestore
+    NODE_DISPLAY_NAME_MAPPINGS["FaceFitAndRestore"] = "Face Fit or Restore"
+
+if FaceFitAndRestoreV2 is not None:
+    NODE_CLASS_MAPPINGS["FaceFitAndRestoreV2"] = FaceFitAndRestoreV2
+    NODE_DISPLAY_NAME_MAPPINGS["FaceFitAndRestoreV2"] = "Face Fit or Restore (v2)"
+
+if FaceWrapper is not None:
+    NODE_CLASS_MAPPINGS["FaceWrapper"] = FaceWrapper
+    NODE_DISPLAY_NAME_MAPPINGS["FaceWrapper"] = "Face Wrapper"
+
+if FaceWrapperV2 is not None:
+    NODE_CLASS_MAPPINGS["FaceWrapperV2"] = FaceWrapperV2
+    NODE_DISPLAY_NAME_MAPPINGS["FaceWrapperV2"] = "Face Wrapper (v2)"
+
+if HighPassFilter is not None:
+    NODE_CLASS_MAPPINGS["HighPassFilter"] = HighPassFilter
+    NODE_DISPLAY_NAME_MAPPINGS["HighPassFilter"] = "High Pass Filter (HPF)"
+
+if ImageFeeder is not None:
+    NODE_CLASS_MAPPINGS["ImageFeeder"] = ImageFeeder
+    NODE_DISPLAY_NAME_MAPPINGS["ImageFeeder"] = "Image Feeder"
+
+if FaceTracker is not None:
+    NODE_CLASS_MAPPINGS["FaceTracker[EXPERIMENTAL]"] = FaceTracker
+    NODE_DISPLAY_NAME_MAPPINGS["FaceTracker[EXPERIMENTAL]"] = "Face Tracker (Experimental)"
 
 __version__ = "1.2.0"

--- a/core/resources/model_loader.py
+++ b/core/resources/model_loader.py
@@ -257,68 +257,6 @@ class ModelOBJ:
         """
         return self._num_landmarks
 
-    def _initialize_landmarks(self) -> np.ndarray:
-        """
-        Initialize landmarks array from UV coordinates
-
-        Returns:
-            numpy.ndarray: Array of landmark coordinates in UV space
-        """
-        landmarks = np.zeros((self._num_landmarks, 2), dtype=np.float32)
-        uvs = np.array(self._uvs, dtype=np.float32)
-
-        for vertex_idx, uv_idx in self._vertex_to_uv.items():
-            if vertex_idx < self._num_landmarks:
-                landmarks[vertex_idx] = uvs[uv_idx]
-
-        return landmarks
-
-    def get_faces(self) -> np.ndarray:
-        """
-        Get face indices as numpy array
-
-        Returns:
-            numpy.ndarray: Array of face indices
-        """
-        return np.array(self._faces, dtype=np.int32)
-
-    def get_transformed_landmarks(self, x_scale: float = 1.0, y_translation: float = 0.0) -> np.ndarray:
-        """
-        Get landmarks with applied transformations
-
-        Args:
-            x_scale: Horizontal scaling factor (0.5 to 1.0)
-            y_translation: Vertical translation (-0.5 to 0.5)
-
-        Returns:
-            numpy.ndarray: Transformed landmarks
-        """
-        if self._landmarks is None:
-            raise RuntimeError("Landmarks not initialized")
-
-        transformed = self._landmarks.copy()
-
-        # Calculate center point
-        center_x = (self._landmarks[:, 0].min() + self._landmarks[:, 0].max()) / 2
-
-        # Calculate horizontal distance from center (normalized to 0-1)
-        dx = np.abs(transformed[:, 0] - center_x)
-
-        # Avoid division by zero
-        if np.abs(center_x) < 1e-6:  # Use small epsilon value
-            influence = np.zeros_like(dx)
-        else:
-            influence = np.clip(dx / center_x, 0, 1)
-
-        # Calculate scaled positions with horizontal influence
-        scale_factor = 1.0 + (x_scale - 1.0) * influence
-        transformed[:, 0] = center_x + (transformed[:, 0] - center_x) * scale_factor
-
-        # Apply vertical translation
-        transformed[:, 1] += y_translation
-
-        return transformed
-
 
 class ModelDlib:
     """Class for loading and managing Dlib face detection models using singleton pattern"""

--- a/faceprocessor_v2/__init__.py
+++ b/faceprocessor_v2/__init__.py
@@ -1,0 +1,41 @@
+"""FaceProcessor v2 package initialization."""
+
+from .pipe import (
+    FacePipe,
+    FrameData,
+    face_pipe_from_legacy,
+    face_pipe_to_legacy,
+    get_or_create_frame,
+    update_frame,
+)
+from .nodes_fit_restore import FaceFitAndRestoreV2
+from .nodes_wrapper import FaceWrapperV2
+from .frame_ids import resolve_frame_ids
+from .utils import (
+    ensure_face_model,
+    get_logger,
+    numpy_to_tensor,
+    tensor_to_numpy,
+)
+from .deformer import TorchDeformer
+from .landmarks import FaceLandmarksBase, MediaPipeLandmarks, DlibRefiner
+
+__all__ = [
+    "FacePipe",
+    "FrameData",
+    "FaceFitAndRestoreV2",
+    "FaceWrapperV2",
+    "TorchDeformer",
+    "FaceLandmarksBase",
+    "MediaPipeLandmarks",
+    "DlibRefiner",
+    "ensure_face_model",
+    "face_pipe_from_legacy",
+    "face_pipe_to_legacy",
+    "get_logger",
+    "get_or_create_frame",
+    "numpy_to_tensor",
+    "resolve_frame_ids",
+    "tensor_to_numpy",
+    "update_frame",
+]

--- a/faceprocessor_v2/deformer.py
+++ b/faceprocessor_v2/deformer.py
@@ -1,0 +1,121 @@
+"""Torch-based face deformer used by the v2 pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+
+
+@dataclass
+class TorchDeformer:
+    """Barycentric triangle-based image deformer implemented with PyTorch."""
+
+    device: Optional[torch.device] = None
+    dtype: torch.dtype = torch.float32
+    padding_mode: str = "zeros"
+    eps: float = 1e-4
+
+    def warp(
+        self,
+        src_image: torch.Tensor,
+        src_landmarks: torch.Tensor,
+        dst_landmarks: torch.Tensor,
+        triangles: torch.Tensor,
+    ) -> torch.Tensor:
+        """Warp ``src_image`` using triangle mappings from ``src_landmarks`` to ``dst_landmarks``."""
+
+        if src_image.ndim != 4 or src_image.shape[0] != 1:
+            raise ValueError("src_image must be shaped as [1, H, W, C]")
+
+        device = self.device or src_image.device
+        dtype = self.dtype
+
+        image = src_image.to(device=device, dtype=dtype)
+        src = src_landmarks.to(device=device, dtype=dtype)
+        dst = dst_landmarks.to(device=device, dtype=dtype)
+        tris = triangles.to(device=device, dtype=torch.long)
+
+        _, height, width, _ = image.shape
+
+        grid = torch.full((1, height, width, 2), -2.0, dtype=dtype, device=device)
+
+        arange_x = torch.arange(width, device=device, dtype=dtype)
+        arange_y = torch.arange(height, device=device, dtype=dtype)
+
+        for tri_indices in tris:
+            dst_tri = dst[tri_indices]
+            src_tri = src[tri_indices]
+
+            min_x = int(torch.floor(dst_tri[:, 0].min()).clamp(0, width - 1).item())
+            max_x = int(torch.ceil(dst_tri[:, 0].max()).clamp(0, width - 1).item())
+            min_y = int(torch.floor(dst_tri[:, 1].min()).clamp(0, height - 1).item())
+            max_y = int(torch.ceil(dst_tri[:, 1].max()).clamp(0, height - 1).item())
+
+            if min_x >= max_x or min_y >= max_y:
+                continue
+
+            dst_matrix = torch.stack(
+                (dst_tri[1] - dst_tri[0], dst_tri[2] - dst_tri[0]), dim=1
+            )
+
+            if torch.abs(torch.linalg.det(dst_matrix)) < self.eps:
+                continue
+
+            dst_inv = torch.inverse(dst_matrix)
+
+            xs = arange_x[min_x : max_x + 1]
+            ys = arange_y[min_y : max_y + 1]
+            yy, xx = torch.meshgrid(ys, xs, indexing="ij")
+
+            coords = torch.stack((xx, yy), dim=-1).reshape(-1, 2)
+            rel = coords - dst_tri[0]
+            uv = rel @ dst_inv
+
+            u = uv[:, 0]
+            v = uv[:, 1]
+            w = 1.0 - u - v
+
+            inside = (
+                (u >= -self.eps)
+                & (v >= -self.eps)
+                & (w >= -self.eps)
+                & (u <= 1 + self.eps)
+                & (v <= 1 + self.eps)
+                & (w <= 1 + self.eps)
+            )
+
+            if not torch.any(inside):
+                continue
+
+            src_coords = (
+                src_tri[0] * w[:, None]
+                + src_tri[1] * u[:, None]
+                + src_tri[2] * v[:, None]
+            )
+
+            selected = coords[inside]
+            src_selected = src_coords[inside]
+
+            grid_x = (2.0 * src_selected[:, 0] / max(width - 1, 1)) - 1.0
+            grid_y = (2.0 * src_selected[:, 1] / max(height - 1, 1)) - 1.0
+
+            xs_sel = selected[:, 0].long()
+            ys_sel = selected[:, 1].long()
+
+            grid[0, ys_sel, xs_sel, 0] = grid_x
+            grid[0, ys_sel, xs_sel, 1] = grid_y
+
+        image_chw = image.permute(0, 3, 1, 2)
+        warped = F.grid_sample(
+            image_chw,
+            grid,
+            mode="bilinear",
+            align_corners=True,
+            padding_mode=self.padding_mode,
+        )
+
+        result = warped.permute(0, 2, 3, 1)
+        return result

--- a/faceprocessor_v2/frame_ids.py
+++ b/faceprocessor_v2/frame_ids.py
@@ -1,0 +1,29 @@
+"""Helpers for resolving frame_id ordering within FacePipe metadata."""
+from __future__ import annotations
+
+from typing import List, Optional, Sequence
+
+from .pipe import FacePipe
+
+
+def resolve_frame_ids(
+    pipe: FacePipe, count: int, fallback: Optional[Sequence[str]] = None
+) -> List[str]:
+    """Return the canonical ``frame_id`` ordering for the provided ``pipe``."""
+
+    frame_order = pipe.meta.get("frame_order")
+    if isinstance(frame_order, Sequence):
+        if len(frame_order) < count:
+            raise ValueError(
+                "FacePipe meta frame_order does not contain enough entries for the current batch",
+            )
+        return [str(frame_order[idx]) for idx in range(count)]
+
+    if fallback is not None:
+        if len(fallback) != count:
+            raise ValueError("Fallback frame_id list length must match the requested count")
+        return list(fallback)
+
+    raise ValueError(
+        "FacePipe meta is missing frame_order information; run FaceFitAndRestoreV2 in Fit mode first",
+    )

--- a/faceprocessor_v2/landmarks.py
+++ b/faceprocessor_v2/landmarks.py
@@ -1,0 +1,204 @@
+"""Facial landmark detectors and refiners for FaceProcessor v2."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import List, Optional, Tuple
+
+import cv2
+import numpy as np
+
+from core.image_processor import ImageProcessor
+from core.lm_mapping import LandmarkMappings
+from core.resources.model_loader import ModelMediaPipe
+
+from .utils import get_logger
+
+try:  # Optional dependency used only when dlib is available.
+    from core.resources.model_loader import ModelDlib  # type: ignore
+except Exception:  # pragma: no cover - exercised only when dlib missing.
+    ModelDlib = None  # type: ignore
+
+
+class FaceLandmarksBase(ABC):
+    """Base class shared between landmark detectors/refiners."""
+
+    def __init__(self, name: str = "FaceLandmarks") -> None:
+        self.logger = get_logger(name)
+        self._image_processor = ImageProcessor()
+
+    def _ensure_numpy_image(self, image) -> Optional[np.ndarray]:
+        if image is None:
+            return None
+        if isinstance(image, np.ndarray):
+            return image
+        try:
+            return self._image_processor.convert_to_numpy(image)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self.logger.error("Failed to convert image to numpy: %s", exc)
+            return None
+
+    @abstractmethod
+    def detect(self, image) -> Optional[np.ndarray]:
+        """Return pixel-space facial landmarks shaped ``[N, 2]``."""
+
+
+class MediaPipeLandmarks(FaceLandmarksBase):
+    """MediaPipe Tasks backed detector that always yields canonical 468-point meshes."""
+
+    CANONICAL_LANDMARKS = 468
+    TASKS_LANDMARKS = 478
+    _CANONICAL_INDICES = np.arange(CANONICAL_LANDMARKS, dtype=np.int64)
+
+    def __init__(self) -> None:
+        super().__init__("MediaPipeLandmarks")
+        self._model: Optional[ModelMediaPipe] = None
+
+    def detect(self, image) -> Optional[np.ndarray]:  # type: ignore[override]
+        """Return ``[468, 2]`` pixel-space landmarks for ``image`` when a face is found."""
+        np_img = self._ensure_numpy_image(image)
+        if np_img is None:
+            return None
+
+        model = self._get_model()
+        try:
+            results = model.face_mesh.process(np_img)
+        except RuntimeError as exc:
+            # MediaPipe Tasks sometimes closes the runner; reinitialize on demand.
+            self.logger.warning("MediaPipe detection failed: %s", exc)
+            self._model = None
+            model = self._get_model()
+            results = model.face_mesh.process(np_img)
+
+        face_landmarks_list = getattr(results, "multi_face_landmarks", None)
+        if not face_landmarks_list:
+            face_landmarks_list = getattr(results, "face_landmarks", None)
+        if not face_landmarks_list:
+            self.logger.info("MediaPipe did not detect a face")
+            return None
+
+        face_landmarks = face_landmarks_list[0]
+        image_height, image_width = np_img.shape[:2]
+        coords: List[Tuple[float, float]] = []
+        landmarks_iter = getattr(face_landmarks, "landmark", face_landmarks)
+
+        for landmark in landmarks_iter:
+            coords.append((landmark.x * image_width, landmark.y * image_height))
+
+        coords_array = np.asarray(coords, dtype=np.float32)
+        normalized = self._normalize_landmarks(coords_array)
+        return normalized
+
+    def _normalize_landmarks(self, coords: np.ndarray) -> Optional[np.ndarray]:
+        count = coords.shape[0]
+        if count == self.CANONICAL_LANDMARKS:
+            return coords
+        if count == self.TASKS_LANDMARKS:
+            # MediaPipe Tasks exposes iris landmarks appended at the end. Drop them
+            # to maintain a canonical 468-point representation.
+            return coords[self._CANONICAL_INDICES]
+
+        if count < self.CANONICAL_LANDMARKS:
+            self.logger.warning(
+                "Unexpected landmark count %s (expected %s)",
+                count,
+                self.CANONICAL_LANDMARKS,
+            )
+            return None
+
+        self.logger.info(
+            "Landmark count %s larger than expected – truncating to %s",
+            count,
+            self.CANONICAL_LANDMARKS,
+        )
+        return coords[: self.CANONICAL_LANDMARKS]
+
+    def _get_model(self) -> ModelMediaPipe:
+        if self._model is None:
+            self._model = ModelMediaPipe()
+        return self._model
+
+
+class DlibRefiner(FaceLandmarksBase):
+    """Optional Dlib-based refiner that overwrites specific landmark groups."""
+
+    _DIRECT_MAPPINGS: Tuple[Tuple[int, int], ...] = tuple(
+        pair for pairs in LandmarkMappings.LANDMARKS_PAIRS.values() for pair in pairs
+    )
+
+    def __init__(self) -> None:
+        super().__init__("DlibRefiner")
+        self._model: Optional[ModelDlib] = None
+        self._available: bool = self._try_initialize()
+        self._warned_unavailable = False
+
+    def detect(self, image) -> Optional[np.ndarray]:  # pragma: no cover - unused
+        return None
+
+    def refine(self, image, landmarks: Optional[np.ndarray]) -> Optional[np.ndarray]:
+        if landmarks is None:
+            return None
+        if not self._available:
+            if not self._warned_unavailable:
+                self.logger.info("dlib not available, skipping refinement")
+                self._warned_unavailable = True
+            return landmarks
+
+        np_img = self._ensure_numpy_image(image)
+        if np_img is None:
+            return landmarks
+
+        dlib_points = self._detect_dlib_landmarks(np_img)
+        if dlib_points is None:
+            return landmarks
+
+        refined = landmarks.copy()
+        for mp_idx, dlib_idx in self._DIRECT_MAPPINGS:
+            if mp_idx >= refined.shape[0]:
+                continue
+            zero_based = dlib_idx - 1
+            if zero_based < 0 or zero_based >= dlib_points.shape[0]:
+                continue
+            refined[mp_idx] = dlib_points[zero_based]
+        return refined
+
+    def _try_initialize(self) -> bool:
+        if ModelDlib is None:
+            return False
+        try:
+            self._model = ModelDlib()
+            return True
+        except Exception as exc:  # pragma: no cover - exercised when dlib absent
+            self.logger.warning("Failed to initialize Dlib models: %s", exc)
+            self._model = None
+            return False
+
+    def _detect_dlib_landmarks(self, image: np.ndarray) -> Optional[np.ndarray]:
+        if self._model is None:
+            return None
+        try:
+            gray = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)
+        except Exception as exc:
+            self.logger.warning("Failed to convert image for dlib refinement: %s", exc)
+            return None
+
+        try:
+            faces = self._model.face_detector(gray)
+        except Exception as exc:
+            self.logger.warning("Dlib face detector error: %s", exc)
+            return None
+
+        if not faces:
+            return None
+
+        try:
+            shape = self._model.shape_predictor(gray, faces[0])
+        except Exception as exc:
+            self.logger.warning("Dlib shape predictor error: %s", exc)
+            return None
+
+        coords = np.zeros((shape.num_parts, 2), dtype=np.float32)
+        for i in range(shape.num_parts):
+            part = shape.part(i)
+            coords[i] = (float(part.x), float(part.y))
+        return coords
+

--- a/faceprocessor_v2/nodes_fit_restore.py
+++ b/faceprocessor_v2/nodes_fit_restore.py
@@ -1,0 +1,318 @@
+"""FaceFitAndRestore v2 node implementation."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import List, Optional, Sequence, Tuple
+
+import cv2
+import numpy as np
+import pandas as pd
+import torch
+
+from core.image_processor import ImageProcessor
+
+from .landmarks import DlibRefiner, MediaPipeLandmarks
+from .pipe import FacePipe, FrameData, face_pipe_from_legacy, face_pipe_to_legacy, get_or_create_frame, update_frame
+from .frame_ids import resolve_frame_ids
+from .utils import ensure_face_model, get_logger, normalize_image_input, numpy_to_tensor, tensor_to_numpy
+
+
+class FaceFitAndRestoreV2:
+    """Detects faces, prepares canonical crops, and restores frames via FacePipe."""
+
+    CATEGORY = "Face Processor"
+    FUNCTION = "process"
+    RETURN_TYPES = ("IMAGE", "MASK", "DICT")
+    RETURN_NAMES = ("image", "mask", "fp_pipe")
+
+    def __init__(self) -> None:
+        self.image_processor = ImageProcessor()
+        self.landmark_detector = MediaPipeLandmarks()
+        self.dlib_refiner = DlibRefiner()
+        self.logger = get_logger("FaceFitAndRestoreV2")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "mode": (["Fit", "Restore"], {"default": "Fit"}),
+                "bbox_size": (["512", "1024", "2048"], {"default": "1024"}),
+                "padding_percent": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 0.5, "step": 0.01}),
+            },
+            "optional": {
+                "image": ("IMAGE",),
+                "image_paths": ("STRING", {"forceInput": True}),
+                "fp_pipe": ("DICT", {"default": None}),
+            },
+        }
+
+    def process(
+        self,
+        mode: str,
+        bbox_size: str,
+        padding_percent: float = 0.0,
+        image: Optional[torch.Tensor] = None,
+        image_paths: Optional[Sequence[str]] = None,
+        fp_pipe: Optional[dict] = None,
+    ):
+        """Execute the selected Fit/Restore branch on the provided batch of frames."""
+        if image is None and image_paths is None:
+            raise ValueError("Either 'image' or 'image_paths' input must be provided")
+
+        source_payload = image if image is not None else image_paths
+        _, tensors, normalized_frame_ids = normalize_image_input(source_payload)
+        if not tensors:
+            raise ValueError("normalize_image_input returned no frames to process")
+        source_paths: Optional[List[Optional[str]]] = None
+
+        pipe = face_pipe_from_legacy(fp_pipe)
+        bbox_size_int = int(bbox_size)
+        if mode == "Fit":
+            frame_ids = normalized_frame_ids
+        else:
+            frame_ids = resolve_frame_ids(pipe, len(tensors), fallback=normalized_frame_ids)
+
+        if len(frame_ids) != len(tensors):
+            raise ValueError("Frame id list length mismatch for FaceFitAndRestoreV2 batch")
+
+        if mode == "Fit":
+            source_paths = self._build_source_path_list(source_payload, len(tensors))
+            images, masks = self._run_fit(
+                tensors=tensors,
+                frame_ids=frame_ids,
+                source_paths=source_paths,
+                pipe=pipe,
+                padding_percent=padding_percent,
+                bbox_size=bbox_size_int,
+            )
+        elif mode == "Restore":
+            images, masks = self._run_restore(tensors=tensors, frame_ids=frame_ids, pipe=pipe)
+        else:
+            raise ValueError(f"Unsupported mode: {mode}")
+
+        legacy_pipe = face_pipe_to_legacy(pipe)
+        return images, masks, legacy_pipe
+
+    # ------------------------------------------------------------------
+    # Fit mode helpers
+    # ------------------------------------------------------------------
+    def _run_fit(
+        self,
+        tensors: List[torch.Tensor],
+        frame_ids: List[str],
+        source_paths: Optional[List[Optional[str]]],
+        pipe: FacePipe,
+        padding_percent: float,
+        bbox_size: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        face_batches: List[torch.Tensor] = []
+        mask_batches: List[torch.Tensor] = []
+
+        if source_paths is None:
+            raise ValueError("Fit mode requires source paths to be resolved")
+
+        if not (len(tensors) == len(frame_ids) == len(source_paths)):
+            raise ValueError("Input batches must share the same length in Fit mode")
+
+        for tensor, frame_id, source_path in zip(tensors, frame_ids, source_paths):
+            face_tensor, mask_tensor, frame_data = self._fit_single(
+                tensor,
+                frame_id,
+                pipe,
+                padding_percent,
+                bbox_size,
+                source_path,
+            )
+
+            face_batches.append(face_tensor)
+            mask_batches.append(mask_tensor)
+
+            if frame_data is not None:
+                update_frame(pipe, frame_data)
+
+        pipe.meta["frame_order"] = list(frame_ids)
+
+        return torch.cat(face_batches, dim=0), torch.cat(mask_batches, dim=0)
+
+    def _fit_single(
+        self,
+        tensor: torch.Tensor,
+        frame_id: str,
+        pipe: FacePipe,
+        padding_percent: float,
+        bbox_size: int,
+        source_path: Optional[str],
+    ) -> Tuple[torch.Tensor, torch.Tensor, Optional[FrameData]]:
+        image_np = self.image_processor.convert_to_numpy(tensor)
+        if image_np is None:
+            self.logger.warning("Failed to convert tensor to numpy for frame %s", frame_id)
+            return tensor, self._solid_mask(tensor.shape[1:3]), None
+
+        landmarks = self.landmark_detector.detect(image_np)
+        if landmarks is None:
+            self.logger.warning("No landmarks detected for frame %s", frame_id)
+            fallback = self.image_processor.resize_image(image_np, bbox_size)
+            if fallback is not None:
+                return (
+                    numpy_to_tensor(fallback),
+                    self._solid_mask((bbox_size, bbox_size)),
+                    self._build_placeholder_frame(frame_id, image_np.shape, source_path, pipe),
+                )
+            return tensor, self._solid_mask(tensor.shape[1:3]), None
+
+        refined_landmarks = self.dlib_refiner.refine(image_np, landmarks)
+        if refined_landmarks is not None:
+            landmarks = refined_landmarks
+
+        landmarks_df = _landmarks_array_to_df(landmarks)
+
+        rotation_angle = self.image_processor.calculate_rotation_angle(landmarks_df)
+        rotated_image, rotated_landmarks = self.image_processor.rotate_image(image_np, landmarks_df)
+        if rotated_image is None or rotated_landmarks is None:
+            self.logger.warning("Rotation failed for frame %s", frame_id)
+            return tensor, self._solid_mask(tensor.shape[1:3]), None
+
+        cropped_face, crop_bbox = self.image_processor.crop_face_to_square(
+            rotated_image, rotated_landmarks, padding_percent
+        )
+        if cropped_face is None or crop_bbox is None:
+            self.logger.warning("Cropping failed for frame %s", frame_id)
+            return tensor, self._solid_mask(tensor.shape[1:3]), None
+
+        final_image = self.image_processor.resize_image(cropped_face, bbox_size)
+        if final_image is None:
+            self.logger.warning("Resizing failed for frame %s", frame_id)
+            return tensor, self._solid_mask(tensor.shape[1:3]), None
+
+        canonical_model = ensure_face_model(pipe, bbox_size, "canonical_models")
+        canonical_landmarks = np.asarray(canonical_model["landmarks"], dtype=np.float32)
+
+        face_tensor = numpy_to_tensor(final_image)
+        mask_tensor = self._solid_mask((bbox_size, bbox_size))
+
+        frame_data = replace(
+            get_or_create_frame(pipe, frame_id),
+            frame_id=frame_id,
+            orig_size=(image_np.shape[0], image_np.shape[1]),
+            bbox=crop_bbox,
+            detected_lm=landmarks.astype(np.float32),
+            target_lm=canonical_landmarks,
+            extra={
+                "rotation_angle": float(rotation_angle),
+                "bbox_size": bbox_size,
+                "padding_percent": float(padding_percent),
+                "source_path": source_path,
+            },
+        )
+
+        return face_tensor, mask_tensor, frame_data
+
+    # ------------------------------------------------------------------
+    # Restore mode helpers
+    # ------------------------------------------------------------------
+    def _run_restore(
+        self,
+        tensors: List[torch.Tensor],
+        frame_ids: List[str],
+        pipe: FacePipe,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        restored_batches: List[torch.Tensor] = []
+        mask_batches: List[torch.Tensor] = []
+
+        if len(tensors) != len(frame_ids):
+            raise ValueError("Restore mode tensors/frame_ids length mismatch")
+
+        for tensor, frame_id in zip(tensors, frame_ids):
+            frame_data = pipe.frames.get(frame_id)
+            if frame_data is None:
+                self.logger.warning("Missing FrameData for frame %s", frame_id)
+                restored_batches.append(tensor)
+                mask_batches.append(self._solid_mask(tensor.shape[1:3]))
+                continue
+
+            restored_tensor, mask_tensor = self._restore_single(tensor, frame_data)
+            restored_batches.append(restored_tensor)
+            mask_batches.append(mask_tensor)
+
+        return torch.cat(restored_batches, dim=0), torch.cat(mask_batches, dim=0)
+
+    def _restore_single(self, tensor: torch.Tensor, frame_data: FrameData) -> Tuple[torch.Tensor, torch.Tensor]:
+        if frame_data.bbox == (0, 0, 0, 0):
+            self.logger.warning("Invalid bbox for frame %s", frame_data.frame_id)
+            return tensor, self._solid_mask(tensor.shape[1:3])
+
+        face_np = tensor_to_numpy(tensor)
+        x, y, w, h = frame_data.bbox
+        orig_h, orig_w = frame_data.orig_size
+
+        restored_image = np.zeros((orig_h, orig_w, 3), dtype=np.uint8)
+        resized_face = cv2.resize(face_np, (w, h), interpolation=cv2.INTER_LANCZOS4)
+        restored_image[y : y + h, x : x + w] = resized_face
+
+        rotation_angle = float(frame_data.extra.get("rotation_angle", 0.0))
+        if rotation_angle:
+            center = (orig_w // 2, orig_h // 2)
+            rotation_matrix = cv2.getRotationMatrix2D(center, -rotation_angle, 1.0)
+            restored_image = cv2.warpAffine(
+                restored_image,
+                rotation_matrix,
+                (orig_w, orig_h),
+                flags=cv2.INTER_LANCZOS4,
+            )
+
+        mask_tensor = self._restore_mask(frame_data, rotation_angle)
+        restored_tensor = numpy_to_tensor(restored_image)
+        return restored_tensor, mask_tensor
+
+    # ------------------------------------------------------------------
+    # Utility helpers
+    # ------------------------------------------------------------------
+    def _solid_mask(self, spatial: Tuple[int, int]) -> torch.Tensor:
+        h, w = spatial
+        return torch.ones((1, h, w), dtype=torch.float32)
+
+    def _restore_mask(self, frame_data: FrameData, rotation_angle: float) -> torch.Tensor:
+        h, w = frame_data.orig_size
+        mask = np.zeros((h, w), dtype=np.float32)
+        x, y, bw, bh = frame_data.bbox
+        mask[y : y + bh, x : x + bw] = 1.0
+
+        if rotation_angle:
+            center = (w // 2, h // 2)
+            rotation_matrix = cv2.getRotationMatrix2D(center, -rotation_angle, 1.0)
+            mask = cv2.warpAffine(mask, rotation_matrix, (w, h), flags=cv2.INTER_LINEAR)
+
+        return torch.from_numpy(mask).unsqueeze(0)
+
+    def _build_placeholder_frame(
+        self,
+        frame_id: str,
+        image_shape: Tuple[int, int, int],
+        source_path: Optional[str],
+        pipe: FacePipe,
+    ) -> FrameData:
+        placeholder = replace(
+            get_or_create_frame(pipe, frame_id),
+            frame_id=frame_id,
+            orig_size=(image_shape[0], image_shape[1]),
+            bbox=(0, 0, 0, 0),
+            detected_lm=None,
+            extra={"error": "no_face_detected", "source_path": source_path},
+        )
+        return placeholder
+
+    def _build_source_path_list(self, payload, expected_len: int) -> List[Optional[str]]:
+        paths: List[Optional[str]] = [None] * expected_len
+        if isinstance(payload, str):
+            paths = [payload]
+        elif isinstance(payload, Sequence) and not isinstance(payload, torch.Tensor):
+            paths = [str(p) if p is not None else None for p in payload]
+        if len(paths) >= expected_len:
+            return paths[:expected_len]
+        return paths + [None] * max(0, expected_len - len(paths))
+
+
+def _landmarks_array_to_df(landmarks: np.ndarray) -> pd.DataFrame:
+    indices = np.arange(len(landmarks), dtype=np.int32)
+    return pd.DataFrame({"x": landmarks[:, 0], "y": landmarks[:, 1], "index": indices})

--- a/faceprocessor_v2/nodes_wrapper.py
+++ b/faceprocessor_v2/nodes_wrapper.py
@@ -167,6 +167,7 @@ class FaceWrapperV2:
         triangles = torch.tensor(unwrap_model["triangles"], dtype=torch.long)
 
         image_out = self.deformer.warp(tensor, src_landmarks, dst_landmarks, triangles)
+        image_out = self._resize_image(image_out, (unwrap_size, unwrap_size))
         mask_image = self._mask_image(mask_tensor, (tensor.shape[1], tensor.shape[2]), tensor.device)
         mask_warped = self.deformer.warp(mask_image, src_landmarks, dst_landmarks, triangles)
         mask_out = self._image_to_mask(mask_warped, (unwrap_size, unwrap_size))
@@ -198,6 +199,7 @@ class FaceWrapperV2:
         triangles = torch.tensor(canonical_model["triangles"], dtype=torch.long)
 
         image_out = self.deformer.warp(tensor, src_landmarks, dst_landmarks, triangles)
+        image_out = self._resize_image(image_out, (canonical_size, canonical_size))
         mask_image = self._mask_image(mask_tensor, (tensor.shape[1], tensor.shape[2]), tensor.device)
         mask_warped = self.deformer.warp(mask_image, src_landmarks, dst_landmarks, triangles)
         mask_out = self._image_to_mask(mask_warped, (canonical_size, canonical_size))
@@ -244,6 +246,14 @@ class FaceWrapperV2:
         if mask.shape[1] != spatial[0] or mask.shape[2] != spatial[1]:
             mask = F.interpolate(mask.unsqueeze(0), size=spatial, mode="bilinear", align_corners=False)[0]
         return mask
+
+    def _resize_image(self, tensor: torch.Tensor, spatial: Tuple[int, int]) -> torch.Tensor:
+        if tensor.shape[1] == spatial[0] and tensor.shape[2] == spatial[1]:
+            return tensor
+
+        chw = tensor.permute(0, 3, 1, 2)
+        resized = F.interpolate(chw, size=spatial, mode="bilinear", align_corners=False)
+        return resized.permute(0, 2, 3, 1)
 
     def _default_mask(self, tensor: torch.Tensor) -> torch.Tensor:
         _, h, w, _ = tensor.shape

--- a/faceprocessor_v2/nodes_wrapper.py
+++ b/faceprocessor_v2/nodes_wrapper.py
@@ -1,0 +1,269 @@
+"""FaceWrapper v2 node built on top of the TorchDeformer."""
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from .deformer import TorchDeformer
+from .pipe import FacePipe, FrameData, face_pipe_from_legacy, face_pipe_to_legacy, update_frame
+from .frame_ids import resolve_frame_ids
+from .utils import ensure_face_model, get_logger
+
+
+class FaceWrapperV2:
+    """Wraps/unwraps canonical face crops using the shared v2 Torch deformer."""
+
+    CATEGORY = "Face Processor"
+    FUNCTION = "process"
+    RETURN_TYPES = ("IMAGE", "MASK", "DICT")
+    RETURN_NAMES = ("image", "mask", "fp_pipe")
+
+    def __init__(self) -> None:
+        self.deformer = TorchDeformer()
+        self.logger = get_logger("FaceWrapperV2")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "mode": (["UNWRAP", "WRAP"], {"default": "UNWRAP"}),
+                "image": ("IMAGE",),
+                "unwrap_size": (["512", "768", "1024"], {"default": "1024"}),
+            },
+            "optional": {
+                "mask": ("MASK", {"default": None}),
+                "fp_pipe": ("DICT", {"default": None}),
+            },
+        }
+
+    def process(
+        self,
+        mode: str,
+        image: torch.Tensor,
+        unwrap_size: str,
+        mask: Optional[torch.Tensor] = None,
+        fp_pipe: Optional[dict] = None,
+    ):
+        """Run the UNWRAP or WRAP stage for the supplied batch of canonical faces."""
+        if image is None:
+            raise ValueError("FaceWrapperV2 requires an input image tensor")
+
+        pipe = face_pipe_from_legacy(fp_pipe)
+        tensors = self._split_image_batch(image)
+        masks = self._split_mask_batch(mask, len(tensors))
+        try:
+            frame_ids = resolve_frame_ids(pipe, len(tensors))
+        except ValueError as exc:
+            raise ValueError(
+                "FaceWrapperV2 requires frame_order metadata from FaceFitAndRestoreV2"
+            ) from exc
+        unwrap_size_int = int(unwrap_size)
+
+        if mode == "UNWRAP":
+            pipe.meta["unwrap_size"] = unwrap_size_int
+            images, mask_tensors = self._run_unwrap(
+                tensors=tensors,
+                masks=masks,
+                frame_ids=frame_ids,
+                pipe=pipe,
+                unwrap_size=unwrap_size_int,
+            )
+        elif mode == "WRAP":
+            active_unwrap_size = int(pipe.meta.get("unwrap_size", unwrap_size_int))
+            images, mask_tensors = self._run_wrap(
+                tensors=tensors,
+                masks=masks,
+                frame_ids=frame_ids,
+                pipe=pipe,
+                unwrap_size=active_unwrap_size,
+            )
+        else:
+            raise ValueError(f"Unsupported FaceWrapperV2 mode: {mode}")
+
+        legacy_pipe = face_pipe_to_legacy(pipe)
+        return torch.cat(images, dim=0), torch.cat(mask_tensors, dim=0), legacy_pipe
+
+    # ------------------------------------------------------------------
+    # UNWRAP / WRAP loops
+    # ------------------------------------------------------------------
+    def _run_unwrap(
+        self,
+        tensors: List[torch.Tensor],
+        masks: List[Optional[torch.Tensor]],
+        frame_ids: List[str],
+        pipe: FacePipe,
+        unwrap_size: int,
+    ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
+        images: List[torch.Tensor] = []
+        mask_tensors: List[torch.Tensor] = []
+
+        for tensor, mask_tensor, frame_id in zip(tensors, masks, frame_ids):
+            frame_data = pipe.frames.get(frame_id)
+            image_out, mask_out = self._unwrap_single(
+                tensor=tensor,
+                mask_tensor=mask_tensor,
+                frame_data=frame_data,
+                pipe=pipe,
+                unwrap_size=unwrap_size,
+            )
+            images.append(image_out)
+            mask_tensors.append(mask_out)
+
+        return images, mask_tensors
+
+    def _run_wrap(
+        self,
+        tensors: List[torch.Tensor],
+        masks: List[Optional[torch.Tensor]],
+        frame_ids: List[str],
+        pipe: FacePipe,
+        unwrap_size: int,
+    ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
+        images: List[torch.Tensor] = []
+        mask_tensors: List[torch.Tensor] = []
+
+        for tensor, mask_tensor, frame_id in zip(tensors, masks, frame_ids):
+            frame_data = pipe.frames.get(frame_id)
+            image_out, mask_out = self._wrap_single(
+                tensor=tensor,
+                mask_tensor=mask_tensor,
+                frame_data=frame_data,
+                pipe=pipe,
+                unwrap_size=unwrap_size,
+            )
+            images.append(image_out)
+            mask_tensors.append(mask_out)
+
+        return images, mask_tensors
+
+    # ------------------------------------------------------------------
+    # Per-frame helpers
+    # ------------------------------------------------------------------
+    def _unwrap_single(
+        self,
+        tensor: torch.Tensor,
+        mask_tensor: Optional[torch.Tensor],
+        frame_data: Optional[FrameData],
+        pipe: FacePipe,
+        unwrap_size: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if frame_data is None:
+            self.logger.warning("Missing FrameData entry for unwrap request")
+            return tensor, self._default_mask(tensor)
+
+        src_landmarks = self._landmarks_to_tensor(frame_data.target_lm)
+        if src_landmarks is None:
+            self.logger.warning("Missing target landmarks for frame %s", frame_data.frame_id)
+            return tensor, self._default_mask(tensor)
+
+        canonical_size = int(frame_data.extra.get("bbox_size", tensor.shape[1]))
+        ensure_face_model(pipe, canonical_size, "canonical_models")
+        unwrap_model = ensure_face_model(pipe, unwrap_size, "unwrap_models")
+
+        dst_landmarks = torch.tensor(unwrap_model["landmarks"], dtype=torch.float32)
+        triangles = torch.tensor(unwrap_model["triangles"], dtype=torch.long)
+
+        image_out = self.deformer.warp(tensor, src_landmarks, dst_landmarks, triangles)
+        mask_image = self._mask_image(mask_tensor, (tensor.shape[1], tensor.shape[2]), tensor.device)
+        mask_warped = self.deformer.warp(mask_image, src_landmarks, dst_landmarks, triangles)
+        mask_out = self._image_to_mask(mask_warped, (unwrap_size, unwrap_size))
+
+        frame_data.extra["unwrap_size"] = unwrap_size
+        update_frame(pipe, frame_data)
+        return image_out, mask_out
+
+    def _wrap_single(
+        self,
+        tensor: torch.Tensor,
+        mask_tensor: Optional[torch.Tensor],
+        frame_data: Optional[FrameData],
+        pipe: FacePipe,
+        unwrap_size: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if frame_data is None:
+            self.logger.warning("Missing FrameData entry for wrap request")
+            return tensor, self._default_mask(tensor)
+
+        src_landmarks = self._unwrap_landmarks(pipe, unwrap_size)
+        dst_landmarks = self._landmarks_to_tensor(frame_data.target_lm)
+        if dst_landmarks is None or src_landmarks is None:
+            self.logger.warning("Incomplete landmark data for frame %s", frame_data.frame_id)
+            return tensor, self._default_mask(tensor)
+
+        canonical_size = int(frame_data.extra.get("bbox_size", tensor.shape[1]))
+        canonical_model = ensure_face_model(pipe, canonical_size, "canonical_models")
+        triangles = torch.tensor(canonical_model["triangles"], dtype=torch.long)
+
+        image_out = self.deformer.warp(tensor, src_landmarks, dst_landmarks, triangles)
+        mask_image = self._mask_image(mask_tensor, (tensor.shape[1], tensor.shape[2]), tensor.device)
+        mask_warped = self.deformer.warp(mask_image, src_landmarks, dst_landmarks, triangles)
+        mask_out = self._image_to_mask(mask_warped, (canonical_size, canonical_size))
+        return image_out, mask_out
+
+    # ------------------------------------------------------------------
+    # Utility helpers
+    # ------------------------------------------------------------------
+    def _split_image_batch(self, image: torch.Tensor) -> List[torch.Tensor]:
+        if image.ndim != 4:
+            raise ValueError("FaceWrapperV2 expects image tensors shaped [B, H, W, 3]")
+        return [image[i : i + 1].detach().clone() for i in range(image.shape[0])]
+
+    def _split_mask_batch(self, mask: Optional[torch.Tensor], batch_len: int) -> List[Optional[torch.Tensor]]:
+        if mask is None:
+            return [None] * batch_len
+
+        if mask.ndim == 2:
+            mask = mask.unsqueeze(0)
+        if mask.ndim != 3:
+            raise ValueError("FaceWrapperV2 expects masks shaped [B, H, W]")
+
+        if mask.shape[0] == 1 and batch_len > 1:
+            return [mask.clone() for _ in range(batch_len)]
+        if mask.shape[0] != batch_len:
+            raise ValueError("Mask batch does not match image batch size")
+        return [mask[i : i + 1].clone() for i in range(batch_len)]
+
+    def _mask_image(
+        self, mask_tensor: Optional[torch.Tensor], spatial: Tuple[int, int], device: torch.device
+    ) -> torch.Tensor:
+        if mask_tensor is None:
+            h, w = spatial
+            base = torch.ones((1, h, w), dtype=torch.float32, device=device)
+        else:
+            base = mask_tensor.detach().clone().to(device=device, dtype=torch.float32)
+        if base.ndim == 2:
+            base = base.unsqueeze(0)
+        return base.clamp(0.0, 1.0).unsqueeze(-1)
+
+    def _image_to_mask(self, tensor: torch.Tensor, spatial: Tuple[int, int]) -> torch.Tensor:
+        mask = tensor[..., 0]
+        mask = mask.clamp(0.0, 1.0)
+        if mask.shape[1] != spatial[0] or mask.shape[2] != spatial[1]:
+            mask = F.interpolate(mask.unsqueeze(0), size=spatial, mode="bilinear", align_corners=False)[0]
+        return mask
+
+    def _default_mask(self, tensor: torch.Tensor) -> torch.Tensor:
+        _, h, w, _ = tensor.shape
+        return torch.ones((1, h, w), dtype=torch.float32, device=tensor.device)
+
+    def _landmarks_to_tensor(self, data) -> Optional[torch.Tensor]:
+        if data is None:
+            return None
+        if isinstance(data, torch.Tensor):
+            tensor = data.detach().clone().float()
+        else:
+            arr = np.asarray(data, dtype=np.float32)
+            if arr.ndim != 2 or arr.shape[1] < 2:
+                return None
+            tensor = torch.from_numpy(arr[:, :2])
+        return tensor
+
+    def _unwrap_landmarks(self, pipe: FacePipe, unwrap_size: int) -> Optional[torch.Tensor]:
+        model = ensure_face_model(pipe, unwrap_size, "unwrap_models")
+        if not model:
+            return None
+        return torch.tensor(model["landmarks"], dtype=torch.float32)
+

--- a/faceprocessor_v2/pipe.py
+++ b/faceprocessor_v2/pipe.py
@@ -1,0 +1,173 @@
+"""Typed data model for the FaceProcessor v2 pipeline."""
+from __future__ import annotations
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, MutableMapping, Optional, Tuple, Union
+
+import numpy as np
+try:  # pragma: no cover - optional torch dependency
+    import torch
+except ImportError:  # pragma: no cover - optional torch dependency
+    torch = None  # type: ignore[assignment]
+
+LandmarkArray = Union[np.ndarray, "torch.Tensor"]
+
+
+@dataclass
+class FrameData:
+    """Container describing a single processed frame."""
+
+    frame_id: str
+    orig_size: Tuple[int, int]
+    bbox: Tuple[int, int, int, int]
+    target_lm: Optional[LandmarkArray] = None
+    detected_lm: Optional[LandmarkArray] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class FacePipe:
+    """High level pipeline contract shared between Fit/Unwrap/Wrap/Restore."""
+
+    frames: Dict[str, FrameData] = field(default_factory=dict)
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+
+def get_or_create_frame(pipe: FacePipe, frame_id: str) -> FrameData:
+    """Return ``frame_id`` from the pipe, creating a placeholder entry if missing."""
+
+    if frame_id not in pipe.frames:
+        pipe.frames[frame_id] = FrameData(
+            frame_id=frame_id,
+            orig_size=(0, 0),
+            bbox=(0, 0, 0, 0),
+        )
+    return pipe.frames[frame_id]
+
+
+def update_frame(pipe: FacePipe, frame: FrameData) -> None:
+    """Store an updated :class:`FrameData` instance in the pipe."""
+
+    pipe.frames[frame.frame_id] = frame
+
+
+def face_pipe_from_legacy(fp_pipe: Optional[MutableMapping[str, Any]]) -> FacePipe:
+    """Adapt the current dictionary-based ``fp_pipe`` into :class:`FacePipe`."""
+
+    if fp_pipe is None:
+        return FacePipe()
+
+    frames: Dict[str, FrameData] = {}
+    for frame_id, frame_info in fp_pipe.get("frames", {}).items():
+        frames[frame_id] = _frame_from_legacy(frame_id, frame_info)
+
+    meta = {k: v for k, v in fp_pipe.items() if k not in {"frames", "target_lm"}}
+
+    target_lm = _landmarks_from_legacy(fp_pipe.get("target_lm"))
+    if target_lm is not None:
+        meta["target_lm"] = target_lm
+
+    return FacePipe(frames=frames, meta=meta)
+
+
+def face_pipe_to_legacy(pipe: FacePipe) -> Dict[str, Any]:
+    """Convert :class:`FacePipe` back to the dict contract used by v1 nodes."""
+
+    legacy: Dict[str, Any] = {k: v for k, v in pipe.meta.items() if k != "target_lm"}
+
+    if (target_lm := pipe.meta.get("target_lm")) is not None:
+        legacy["target_lm"] = _landmarks_to_legacy(target_lm)
+
+    legacy_frames: Dict[str, Any] = {}
+    for frame_id, frame in pipe.frames.items():
+        legacy_frames[frame_id] = _frame_to_legacy(frame)
+    legacy["frames"] = legacy_frames
+    return legacy
+
+
+def _frame_from_legacy(frame_id: str, frame_info: MutableMapping[str, Any]) -> FrameData:
+    orig_size = _normalize_hw(frame_info.get("orig_size"))
+    if orig_size == (0, 0):
+        orig_size = _normalize_hw(frame_info.get("original_image_shape"))
+
+    bbox = _normalize_bbox(frame_info.get("bbox"))
+    if bbox == (0, 0, 0, 0):
+        bbox = _normalize_bbox(frame_info.get("crop_bbox"))
+
+    detected_lm = _landmarks_from_legacy(frame_info.get("detected_lm"))
+    target_lm = _landmarks_from_legacy(frame_info.get("target_lm"))
+
+    extra = {
+        k: v
+        for k, v in frame_info.items()
+        if k not in {"orig_size", "original_image_shape", "bbox", "crop_bbox", "detected_lm"}
+    }
+
+    return FrameData(
+        frame_id=frame_id,
+        orig_size=orig_size,
+        bbox=bbox,
+        detected_lm=detected_lm,
+        target_lm=target_lm,
+        extra=extra,
+    )
+
+
+def _frame_to_legacy(frame: FrameData) -> Dict[str, Any]:
+    legacy_frame: Dict[str, Any] = dict(frame.extra)
+
+    legacy_frame["orig_size"] = list(frame.orig_size)
+    legacy_frame["bbox"] = list(frame.bbox)
+
+    if frame.detected_lm is not None:
+        legacy_frame["detected_lm"] = _landmarks_to_legacy(frame.detected_lm)
+
+    if frame.target_lm is not None:
+        legacy_frame["target_lm"] = _landmarks_to_legacy(frame.target_lm)
+
+    return legacy_frame
+
+
+def _landmarks_from_legacy(data: Optional[MutableMapping[str, Any]]) -> Optional[np.ndarray]:
+    if not data:
+        return None
+
+    x = np.asarray(data.get("x", []), dtype=np.float32)
+    y = np.asarray(data.get("y", []), dtype=np.float32)
+    if x.size == 0 or y.size == 0 or x.shape != y.shape:
+        return None
+
+    return np.stack([x, y], axis=-1)
+
+
+def _landmarks_to_legacy(data: LandmarkArray) -> Dict[str, Any]:
+    if torch is not None and isinstance(data, torch.Tensor):
+        arr = data.detach().cpu().numpy()
+    else:
+        arr = np.asarray(data)
+
+    if arr.ndim != 2 or arr.shape[1] < 2:
+        raise ValueError("Landmark tensor must be shaped [N, 2]")
+
+    arr = arr[:, :2]
+    return {"x": arr[:, 0].tolist(), "y": arr[:, 1].tolist(), "indices": list(range(arr.shape[0]))}
+
+
+def _normalize_hw(value: Any) -> Tuple[int, int]:
+    if value is None:
+        return (0, 0)
+
+    if isinstance(value, (list, tuple)):
+        if len(value) >= 2:
+            return (int(value[0]), int(value[1]))
+    return (0, 0)
+
+
+def _normalize_bbox(value: Any) -> Tuple[int, int, int, int]:
+    if value is None:
+        return (0, 0, 0, 0)
+    if isinstance(value, (list, tuple)) and len(value) >= 4:
+        return (int(value[0]), int(value[1]), int(value[2]), int(value[3]))
+    return (0, 0, 0, 0)

--- a/faceprocessor_v2/utils.py
+++ b/faceprocessor_v2/utils.py
@@ -1,0 +1,154 @@
+"""Utility helpers for the FaceProcessor v2 pipeline."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, Optional, Sequence
+
+import numpy as np
+from PIL import Image
+
+try:  # pragma: no cover - optional torch dependency for imports
+    import torch
+except ImportError:  # pragma: no cover - optional torch dependency for imports
+    torch = None  # type: ignore[assignment]
+
+from core.base_mesh import MediapipeBaseLandmarks
+
+if TYPE_CHECKING:
+    from .pipe import FacePipe
+
+
+def _require_torch() -> None:
+    if torch is None:  # pragma: no cover - executed only when torch is unavailable
+        raise RuntimeError(
+            "PyTorch is required for this operation but is not installed in the current environment",
+        )
+
+
+def tensor_to_numpy(image: torch.Tensor) -> np.ndarray:
+    """Convert a batched ComfyUI tensor ``[B, H, W, C]`` to ``[H, W, C]`` numpy image."""
+
+    _require_torch()
+    if image.ndim != 4:
+        raise ValueError(
+            f"Expected a 4D tensor shaped [B, H, W, C], got tensor with shape {tuple(image.shape)}",
+        )
+
+    batch = image.shape[0]
+    if batch != 1:
+        raise ValueError("tensor_to_numpy currently supports only a single image (batch size of 1).")
+
+    tensor = image[0].detach().cpu().clamp(0.0, 1.0)
+    np_img = (tensor.numpy() * 255.0).round().astype(np.uint8)
+    return np_img
+
+
+def numpy_to_tensor(np_img: np.ndarray) -> torch.Tensor:
+    """Convert a numpy image ``[H, W, C]`` to a ComfyUI tensor ``[1, H, W, C]``."""
+
+    _require_torch()
+    if np_img.ndim != 3:
+        raise ValueError(
+            f"Expected a numpy array shaped [H, W, C], got array with shape {tuple(np_img.shape)}",
+        )
+
+    tensor = torch.from_numpy(np_img).float() / 255.0
+    tensor = tensor.clamp(0.0, 1.0)
+    tensor = tensor.unsqueeze(0)  # Add batch dimension.
+    return tensor
+
+
+def get_logger(name: str = "FaceProcessor", level: int = logging.INFO) -> logging.Logger:
+    """Return a module-wide configured logger instance."""
+
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter("[%(levelname)s] %(name)s: %(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.propagate = False
+    logger.setLevel(level)
+    return logger
+
+
+def _ensure_tensor_4d(image: torch.Tensor) -> torch.Tensor:
+    """Return ``image`` reshaped to ``[1, H, W, C]`` if possible."""
+
+    _require_torch()
+    if image.ndim == 3:
+        return image.unsqueeze(0)
+    if image.ndim == 4:
+        return image
+    raise ValueError(
+        "normalize_image_input expected tensor shaped [H, W, C] or [B, H, W, C], "
+        f"got shape {tuple(image.shape)}",
+    )
+
+
+def _tensor_to_batch_list(tensor: torch.Tensor) -> list[torch.Tensor]:
+    """Split a ``[B, H, W, C]`` tensor into a list of ``[1, H, W, C]`` tensors."""
+
+    _require_torch()
+    tensor = tensor.detach().clone()
+    return [tensor[i : i + 1] for i in range(tensor.shape[0])]
+
+
+def _load_image_tensor(path: str) -> torch.Tensor:
+    """Load an image from ``path`` and convert it to ``[1, H, W, 3]`` tensor."""
+
+    _require_torch()
+    img = Image.open(path).convert("RGB")
+    np_img = np.array(img)
+    return numpy_to_tensor(np_img)
+
+
+def normalize_image_input(image_or_paths) -> tuple[str, list[torch.Tensor], list[str]]:
+    """Normalize different image entrypoints into a common representation."""
+
+    if torch is not None and isinstance(image_or_paths, torch.Tensor):
+        tensor = _ensure_tensor_4d(image_or_paths)
+        tensors = _tensor_to_batch_list(tensor)
+        frame_ids = [f"frame_{idx:04d}" for idx in range(len(tensors))]
+        return "tensor_batch", tensors, frame_ids
+
+    if isinstance(image_or_paths, (str, Path)):
+        image_or_paths = [image_or_paths]
+
+    if isinstance(image_or_paths, Sequence):
+        tensors: list[torch.Tensor] = []
+        frame_ids: list[str] = []
+        for path in image_or_paths:
+            if not isinstance(path, (str, Path)):
+                raise TypeError(
+                    "normalize_image_input expected a sequence of paths when not given a tensor",
+                )
+            path = Path(path)
+            tensors.append(_load_image_tensor(str(path)))
+            frame_ids.append(path.stem or path.name)
+        return "paths", tensors, frame_ids
+
+    raise TypeError(
+        "normalize_image_input supports torch.Tensor or a sequence of file paths. "
+        f"Got value of type {type(image_or_paths)!r}.",
+    )
+
+
+def ensure_face_model(pipe: "FacePipe", size: int, bucket: str = "canonical_models") -> Dict[str, list]:
+    """Ensure triangulation data for ``size`` exists in ``pipe.meta`` and return it."""
+
+    models: Dict[str, Dict[str, list]] = pipe.meta.setdefault(bucket, {})
+    key = str(size)
+    model = models.get(key)
+    if model is None:
+        triangles, landmarks = MediapipeBaseLandmarks.get_face_triangles((size, size))
+        model = {
+            "size": size,
+            "triangles": triangles.astype(np.int64).tolist(),
+            "landmarks": landmarks.astype(np.float32).tolist(),
+        }
+        models[key] = model
+    return model
+
+

--- a/nodes/face_tracker.py
+++ b/nodes/face_tracker.py
@@ -1,3 +1,9 @@
+"""Experimental tracker prototype kept for reference only.
+
+This node is not part of the core FaceProcessor v2.0 pipeline. It remains in the
+repository for future experimentation and should be treated as unstable.
+"""
+
 import cv2
 
 from ..core.face_detector import FaceDetector

--- a/tests/test_frame_id_resolution.py
+++ b/tests/test_frame_id_resolution.py
@@ -1,0 +1,50 @@
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+PKG_NAME = "faceprocessor_v2"
+if PKG_NAME not in sys.modules:
+    pkg = types.ModuleType(PKG_NAME)
+    pkg.__path__ = [str(ROOT / PKG_NAME)]
+    sys.modules[PKG_NAME] = pkg
+
+pipe_spec = importlib.util.spec_from_file_location(
+    f"{PKG_NAME}.pipe", ROOT / PKG_NAME / "pipe.py"
+)
+fp2_pipe = importlib.util.module_from_spec(pipe_spec)
+assert pipe_spec and pipe_spec.loader
+sys.modules[pipe_spec.name] = fp2_pipe
+pipe_spec.loader.exec_module(fp2_pipe)
+FacePipe = fp2_pipe.FacePipe
+
+frame_ids_spec = importlib.util.spec_from_file_location(
+    f"{PKG_NAME}.frame_ids", ROOT / PKG_NAME / "frame_ids.py"
+)
+fp2_frame_ids = importlib.util.module_from_spec(frame_ids_spec)
+assert frame_ids_spec and frame_ids_spec.loader
+sys.modules[frame_ids_spec.name] = fp2_frame_ids
+frame_ids_spec.loader.exec_module(fp2_frame_ids)
+resolve_frame_ids = fp2_frame_ids.resolve_frame_ids
+
+
+def test_resolve_frame_ids_uses_meta_order():
+    pipe = FacePipe(meta={"frame_order": ["frame_a", "frame_b", "frame_c"]})
+    assert resolve_frame_ids(pipe, 2) == ["frame_a", "frame_b"]
+
+
+def test_resolve_frame_ids_requires_enough_entries():
+    pipe = FacePipe(meta={"frame_order": ["frame_a"]})
+    with pytest.raises(ValueError):
+        resolve_frame_ids(pipe, 2)
+
+
+def test_resolve_frame_ids_falls_back_when_missing():
+    pipe = FacePipe()
+    assert resolve_frame_ids(pipe, 1, fallback=["fallback_0"]) == ["fallback_0"]

--- a/tests/test_torch_deformer.py
+++ b/tests/test_torch_deformer.py
@@ -1,0 +1,46 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from faceprocessor_v2.deformer import TorchDeformer
+
+
+def make_checker_image(size: int = 4) -> torch.Tensor:
+    base = torch.zeros((1, size, size, 3), dtype=torch.float32)
+    for y in range(size):
+        for x in range(size):
+            base[0, y, x] = torch.tensor([(x + y) / (2 * size), x / size, y / size])
+    return base
+
+
+def test_identity_warp_returns_same_image():
+    image = make_checker_image(4)
+    landmarks = torch.tensor(
+        [[0, 0], [3, 0], [3, 3], [0, 3]], dtype=torch.float32
+    )
+    triangles = torch.tensor([[0, 1, 2], [0, 2, 3]], dtype=torch.long)
+
+    deformer = TorchDeformer()
+    warped = deformer.warp(image, landmarks, landmarks, triangles)
+
+    assert torch.allclose(warped, image, atol=1e-4)
+
+
+def test_single_triangle_translation_moves_colors():
+    image = torch.zeros((1, 5, 5, 3), dtype=torch.float32)
+    image[:, 1:3, 1:3] = torch.tensor([[[1.0, 0.0, 0.0]]])
+
+    src_landmarks = torch.tensor(
+        [[1.0, 1.0], [3.0, 1.0], [1.0, 3.0]], dtype=torch.float32
+    )
+    dst_landmarks = torch.tensor(
+        [[2.0, 1.0], [4.0, 1.0], [2.0, 3.0]], dtype=torch.float32
+    )
+    triangles = torch.tensor([[0, 1, 2]], dtype=torch.long)
+
+    deformer = TorchDeformer()
+    warped = deformer.warp(image, src_landmarks, dst_landmarks, triangles)
+
+    translated_patch = warped[:, 1:3, 2:4]
+    assert torch.all(translated_patch[..., 0] > 0.9)
+    assert torch.all(translated_patch[..., 1:] < 1e-3)

--- a/tests/test_v2_roundtrip.py
+++ b/tests/test_v2_roundtrip.py
@@ -1,0 +1,99 @@
+"""Integration test covering the Fit→Unwrap→Wrap→Restore v2 pipeline."""
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+import torch.nn.functional as F  # noqa: E402  # pylint: disable=wrong-import-position
+
+from faceprocessor_v2.nodes_fit_restore import FaceFitAndRestoreV2
+from faceprocessor_v2.nodes_wrapper import FaceWrapperV2
+from faceprocessor_v2.pipe import get_or_create_frame
+from faceprocessor_v2.utils import ensure_face_model
+
+
+def _gradient_image(size: int = 512) -> torch.Tensor:
+    coords = torch.linspace(0.0, 1.0, size, dtype=torch.float32)
+    grid_x = coords.repeat(size, 1)
+    grid_y = coords.view(-1, 1).repeat(1, size)
+    grid_z = torch.flip(grid_x, dims=[1])
+    image = torch.stack((grid_x, grid_y, grid_z), dim=-1)
+    return image.unsqueeze(0)
+
+
+def test_v2_roundtrip_pipeline(monkeypatch):
+    node = FaceFitAndRestoreV2()
+    wrapper = FaceWrapperV2()
+    input_image = _gradient_image()
+    bbox_size = "512"
+
+    def fake_fit_single(self, tensor, frame_id, pipe, padding_percent, bbox_size, source_path):
+        canonical_model = ensure_face_model(pipe, bbox_size, "canonical_models")
+        canonical_landmarks = np.asarray(canonical_model["landmarks"], dtype=np.float32)
+
+        resized = tensor
+        if tensor.shape[1] != bbox_size:
+            resized = (
+                F.interpolate(
+                    tensor.permute(0, 3, 1, 2),
+                    size=(bbox_size, bbox_size),
+                    mode="bilinear",
+                    align_corners=False,
+                ).permute(0, 2, 3, 1)
+            )
+
+        mask = torch.ones((1, bbox_size, bbox_size), dtype=torch.float32)
+
+        frame_data = replace(
+            get_or_create_frame(pipe, frame_id),
+            frame_id=frame_id,
+            orig_size=(tensor.shape[1], tensor.shape[2]),
+            bbox=(0, 0, tensor.shape[2], tensor.shape[1]),
+            detected_lm=canonical_landmarks.copy(),
+            target_lm=canonical_landmarks.copy(),
+            extra={"bbox_size": bbox_size, "rotation_angle": 0.0},
+        )
+        return resized.clone(), mask, frame_data
+
+    monkeypatch.setattr(FaceFitAndRestoreV2, "_fit_single", fake_fit_single)
+
+    fit_image, fit_mask, pipe = node.process(
+        mode="Fit",
+        bbox_size=bbox_size,
+        padding_percent=0.0,
+        image=input_image,
+    )
+
+    unwrap_image, unwrap_mask, pipe = wrapper.process(
+        mode="UNWRAP",
+        image=fit_image,
+        unwrap_size=bbox_size,
+        mask=fit_mask,
+        fp_pipe=pipe,
+    )
+
+    rewrapped_image, rewrapped_mask, pipe = wrapper.process(
+        mode="WRAP",
+        image=unwrap_image,
+        unwrap_size=bbox_size,
+        mask=unwrap_mask,
+        fp_pipe=pipe,
+    )
+
+    restored_image, restored_mask, _ = node.process(
+        mode="Restore",
+        bbox_size=bbox_size,
+        padding_percent=0.0,
+        image=rewrapped_image,
+        fp_pipe=pipe,
+    )
+
+    assert restored_image.shape == input_image.shape
+    assert restored_mask.shape[1:] == input_image.shape[1:3]
+
+    mse = torch.mean((restored_image - input_image) ** 2).item()
+    assert mse < 1e-4
+    assert torch.mean(rewrapped_mask).item() > 0.9


### PR DESCRIPTION
## Summary
- deduplicate the canonical Mediapipe OBJ helpers and refresh docstrings for the v2 Fit/Wrapper nodes, TorchDeformer, and MediaPipeLandmarks so the public API is properly described
- add a synthetic Fit→UNWRAP→WRAP→Restore integration test that exercises the torch deformer loop end-to-end

## Testing
- FACEPROCESSOR_SKIP_IMPORTS=1 pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69190779c45c832cb191c7b4a4490a2f)