### PR TITLE
Surface missing dependencies for Face Fit nodes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -7,7 +7,37 @@ _SKIP_IMPORTS = os.environ.get("FACEPROCESSOR_SKIP_IMPORTS") == "1"
 if not _SKIP_IMPORTS:
     _pkg_name = __name__.split(".")[0]
 
-    def _optional_import(importer):  # pragma: no cover - exercised during import
+    def _missing_dependency_stub(node_name: str, display_name: str, exc: Exception, *,
+                                 category: str, input_types: dict, return_types: tuple,
+                                 return_names: tuple, function_name: str = "process"):
+        """Build a lightweight ComfyUI node that surfaces missing dependency errors."""
+
+        missing = getattr(exc, "name", None) or exc.__class__.__name__
+        details = str(exc)
+
+        class _MissingNode:
+            CATEGORY = category
+            FUNCTION = function_name
+            RETURN_TYPES = return_types
+            RETURN_NAMES = return_names
+
+            @classmethod
+            def INPUT_TYPES(cls):  # pragma: no cover - simple accessors
+                return input_types
+
+            def process(self, *_, **__):  # pragma: no cover - executed only when deps missing
+                raise RuntimeError(
+                    f"{display_name} is unavailable because the '{missing}' dependency could not be imported. "
+                    "Install the packages listed in requirements.txt and restart ComfyUI. "
+                    f"Original error: {details}"
+                )
+
+        _MissingNode.__name__ = f"{node_name}Unavailable"
+        return _MissingNode
+
+    def _optional_import(importer, *, node_name: str, display_name: str, stub_factory=None):
+        """Import a node while gracefully handling missing optional dependencies."""
+
         try:
             return importer()
         except (ModuleNotFoundError, ImportError) as exc:  # missing optional deps (torch, cv2, etc.)
@@ -18,13 +48,74 @@ if not _SKIP_IMPORTS:
                 f"Skipping FaceProcessor node import due to missing dependency: {exc}",
                 RuntimeWarning,
             )
+            if stub_factory is not None:
+                return stub_factory(exc)
             return None
 
-    ImageFeeder = _optional_import(lambda: getattr(import_module(".nodes.image_feeder", __name__), "ImageFeeder"))
-    HighPassFilter = _optional_import(lambda: getattr(import_module(".nodes.image_filters", __name__), "HighPassFilter"))
-    FaceFitAndRestore = _optional_import(lambda: getattr(import_module(".faceprocessor.nodes_fit_restore", __name__), "FaceFitAndRestore"))
-    FaceWrapper = _optional_import(lambda: getattr(import_module(".faceprocessor.nodes_wrapper", __name__), "FaceWrapper"))
-    FaceTracker = _optional_import(lambda: getattr(import_module(".nodes.face_tracker", __name__), "FaceTracker"))
+    ImageFeeder = _optional_import(
+        lambda: getattr(import_module(".nodes.image_feeder", __name__), "ImageFeeder"),
+        node_name="ImageFeeder",
+        display_name="Image Feeder",
+    )
+    HighPassFilter = _optional_import(
+        lambda: getattr(import_module(".nodes.image_filters", __name__), "HighPassFilter"),
+        node_name="HighPassFilter",
+        display_name="High Pass Filter (HPF)",
+    )
+    FaceFitAndRestore = _optional_import(
+        lambda: getattr(import_module(".faceprocessor.nodes_fit_restore", __name__), "FaceFitAndRestore"),
+        node_name="FaceFitAndRestore",
+        display_name="Face Fit or Restore",
+        stub_factory=lambda exc: _missing_dependency_stub(
+            node_name="FaceFitAndRestore",
+            display_name="Face Fit or Restore",
+            exc=exc,
+            category="Face Processor",
+            input_types={
+                "required": {
+                    "mode": (["Fit", "Restore"], {"default": "Fit"}),
+                    "bbox_size": (["512", "1024", "2048"], {"default": "1024"}),
+                    "padding_percent": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 0.5, "step": 0.01}),
+                },
+                "optional": {
+                    "image": ("IMAGE",),
+                    "image_paths": ("STRING", {"forceInput": True}),
+                    "fp_pipe": ("DICT", {"default": None}),
+                },
+            },
+            return_types=("IMAGE", "MASK", "DICT"),
+            return_names=("image", "mask", "fp_pipe"),
+        ),
+    )
+    FaceWrapper = _optional_import(
+        lambda: getattr(import_module(".faceprocessor.nodes_wrapper", __name__), "FaceWrapper"),
+        node_name="FaceWrapper",
+        display_name="Face Wrapper",
+        stub_factory=lambda exc: _missing_dependency_stub(
+            node_name="FaceWrapper",
+            display_name="Face Wrapper",
+            exc=exc,
+            category="Face Processor",
+            input_types={
+                "required": {
+                    "mode": (["UNWRAP", "WRAP"], {"default": "UNWRAP"}),
+                    "image": ("IMAGE",),
+                    "unwrap_size": (["512", "768", "1024"], {"default": "1024"}),
+                },
+                "optional": {
+                    "mask": ("MASK", {"default": None}),
+                    "fp_pipe": ("DICT", {"default": None}),
+                },
+            },
+            return_types=("IMAGE", "MASK", "DICT"),
+            return_names=("image", "mask", "fp_pipe"),
+        ),
+    )
+    FaceTracker = _optional_import(
+        lambda: getattr(import_module(".nodes.face_tracker", __name__), "FaceTracker"),
+        node_name="FaceTracker",
+        display_name="Face Tracker (Experimental)",
+    )
 else:  # pragma: no cover - used only when optional deps are missing
     ImageFeeder = None
     HighPassFilter = None

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,13 @@ from importlib import import_module
 
 _SKIP_IMPORTS = os.environ.get("FACEPROCESSOR_SKIP_IMPORTS") == "1"
 
+_MISSING_DEPENDENCY_HINTS = {
+    "core": (
+        "Ensure the bundled 'core' module is available by copying the entire ComfyUI_FaceProcessor "
+        "folder (including the 'core' directory) into ComfyUI/custom_nodes and then restart ComfyUI."
+    ),
+}
+
 if not _SKIP_IMPORTS:
     _pkg_name = __name__.split(".")[0]
 
@@ -14,12 +21,17 @@ if not _SKIP_IMPORTS:
 
         missing = getattr(exc, "name", None) or exc.__class__.__name__
         details = str(exc)
+        hint = _MISSING_DEPENDENCY_HINTS.get(
+            missing,
+            "Install the packages listed in requirements.txt and restart ComfyUI.",
+        )
 
         class _MissingNode:
             CATEGORY = category
             FUNCTION = function_name
             RETURN_TYPES = return_types
             RETURN_NAMES = return_names
+            _faceprocessor_missing_dependency_stub = True
 
             @classmethod
             def INPUT_TYPES(cls):  # pragma: no cover - simple accessors
@@ -28,8 +40,7 @@ if not _SKIP_IMPORTS:
             def process(self, *_, **__):  # pragma: no cover - executed only when deps missing
                 raise RuntimeError(
                     f"{display_name} is unavailable because the '{missing}' dependency could not be imported. "
-                    "Install the packages listed in requirements.txt and restart ComfyUI. "
-                    f"Original error: {details}"
+                    f"{hint} Original error: {details}"
                 )
 
         _MissingNode.__name__ = f"{node_name}Unavailable"
@@ -116,12 +127,17 @@ if not _SKIP_IMPORTS:
         node_name="FaceTracker",
         display_name="Face Tracker (Experimental)",
     )
+    def _is_placeholder(node_cls) -> bool:
+        return getattr(node_cls, "_faceprocessor_missing_dependency_stub", False)
 else:  # pragma: no cover - used only when optional deps are missing
     ImageFeeder = None
     HighPassFilter = None
     FaceFitAndRestore = None
     FaceWrapper = None
     FaceTracker = None
+
+    def _is_placeholder(_):
+        return False
 
 # Get the path to the current directory
 NODE_PATH = os.path.dirname(os.path.realpath(__file__))
@@ -132,16 +148,18 @@ NODE_DISPLAY_NAME_MAPPINGS = {}
 if FaceFitAndRestore is not None:
     NODE_CLASS_MAPPINGS["FaceFitAndRestore"] = FaceFitAndRestore
     NODE_DISPLAY_NAME_MAPPINGS["FaceFitAndRestore"] = "Face Fit or Restore"
-    # Backwards compatibility with saved workflows referencing the legacy v2 name
-    NODE_CLASS_MAPPINGS["FaceFitAndRestoreV2"] = FaceFitAndRestore
-    NODE_DISPLAY_NAME_MAPPINGS["FaceFitAndRestoreV2"] = "Face Fit or Restore"
+    if not _is_placeholder(FaceFitAndRestore):
+        # Backwards compatibility with saved workflows referencing the legacy v2 name
+        NODE_CLASS_MAPPINGS["FaceFitAndRestoreV2"] = FaceFitAndRestore
+        NODE_DISPLAY_NAME_MAPPINGS["FaceFitAndRestoreV2"] = "Face Fit or Restore"
 
 if FaceWrapper is not None:
     NODE_CLASS_MAPPINGS["FaceWrapper"] = FaceWrapper
     NODE_DISPLAY_NAME_MAPPINGS["FaceWrapper"] = "Face Wrapper"
-    # Backwards compatibility with saved workflows referencing the legacy v2 name
-    NODE_CLASS_MAPPINGS["FaceWrapperV2"] = FaceWrapper
-    NODE_DISPLAY_NAME_MAPPINGS["FaceWrapperV2"] = "Face Wrapper"
+    if not _is_placeholder(FaceWrapper):
+        # Backwards compatibility with saved workflows referencing the legacy v2 name
+        NODE_CLASS_MAPPINGS["FaceWrapperV2"] = FaceWrapper
+        NODE_DISPLAY_NAME_MAPPINGS["FaceWrapperV2"] = "Face Wrapper"
 
 if HighPassFilter is not None:
     NODE_CLASS_MAPPINGS["HighPassFilter"] = HighPassFilter

--- a/faceprocessor/landmarks.py
+++ b/faceprocessor/landmarks.py
@@ -7,14 +7,14 @@ from typing import List, Optional, Tuple
 import cv2
 import numpy as np
 
-from core.image_processor import ImageProcessor
-from core.lm_mapping import LandmarkMappings
-from core.resources.model_loader import ModelMediaPipe
+from ..core.image_processor import ImageProcessor
+from ..core.lm_mapping import LandmarkMappings
+from ..core.resources.model_loader import ModelMediaPipe
 
 from .utils import get_logger
 
 try:  # Optional dependency used only when dlib is available.
-    from core.resources.model_loader import ModelDlib  # type: ignore
+    from ..core.resources.model_loader import ModelDlib  # type: ignore
 except Exception:  # pragma: no cover - exercised only when dlib missing.
     ModelDlib = None  # type: ignore
 

--- a/faceprocessor/nodes_fit_restore.py
+++ b/faceprocessor/nodes_fit_restore.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 import torch
 
-from core.image_processor import ImageProcessor
+from ..core.image_processor import ImageProcessor
 
 from .landmarks import DlibRefiner, MediaPipeLandmarks
 from .pipe import FacePipe, FrameData, face_pipe_from_legacy, face_pipe_to_legacy, get_or_create_frame, update_frame

--- a/faceprocessor/utils.py
+++ b/faceprocessor/utils.py
@@ -13,7 +13,7 @@ try:  # pragma: no cover - optional torch dependency for imports
 except ImportError:  # pragma: no cover - optional torch dependency for imports
     torch = None  # type: ignore[assignment]
 
-from core.base_mesh import MediapipeBaseLandmarks
+from ..core.base_mesh import MediapipeBaseLandmarks
 
 if TYPE_CHECKING:
     from .pipe import FacePipe


### PR DESCRIPTION
## Summary
- add a helper that builds placeholder nodes when optional dependencies prevent importing the real implementation
- use the helper so Face Fit or Restore and Face Wrapper still register in ComfyUI and surface a clear error about the missing dependency instead of disappearing

## Testing
- python - <<'PY'
import sys
sys.path.append('.')
import ComfyUI_FaceProcessor as fp
print(sorted(fp.NODE_CLASS_MAPPINGS.keys()))
for name, cls in fp.NODE_CLASS_MAPPINGS.items():
    print(name, cls)
PY


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919b2a68bb0832c9a3b5f11913ec580)